### PR TITLE
Added max length for leave code in Add Leave Category

### DIFF
--- a/Client_CSILMS/src/hradmin/AddLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/AddLeaveCategory.js
@@ -16,6 +16,7 @@ import { Redirect, withRouter } from "react-router-dom";
 import { isHrRole } from "../util/APIUtils";
 import { fetchData } from "../util/APIUtils";
 import { API_BASE_URL } from "../constants";
+import { confirmAlert } from "react-confirm-alert";
 
 class AddLeaveCategory extends Component {
   constructor(props) {
@@ -75,8 +76,33 @@ class AddLeaveCategory extends Component {
         url: API_BASE_URL + "/leavecategory",
         method: "POST",
         body: JSON.stringify(addLeaveCategory)
+      })
+      .then(response => {
+        this.toggleApprove();
+        confirmAlert({
+          message: "Leave Category has been successfully added!",
+          buttons: [
+            {
+              label: "OK",
+              onClick: () => this.props.history.push("/leavecategory")
+            }
+          ]
+        });
+      })
+      .catch(error => {
+        if (error.status === 401) {
+          this.props.history.push("/login");
+        } else {
+          confirmAlert({
+            message: error.status + " : " + error.message,
+            buttons: [
+              {
+                label: "OK"
+              }
+            ]
+          });
+        }
       });
-      this.props.history.push("/leavecategory");
     }
   }
 
@@ -115,6 +141,7 @@ class AddLeaveCategory extends Component {
                   id="leaveCode"
                   value={leaveCode}
                   onChange={this.handleChange}
+                  maxLength="3"
                   required
                 />
               </Col>

--- a/Client_CSILMS/src/hradmin/EditLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/EditLeaveCategory.js
@@ -161,6 +161,7 @@ class EditLeaveCategory extends Component {
                   id="leaveCode"
                   value={leaveCode}
                   onChange={this.handleChange}
+                  maxLength="3"
                   required
                   disabled
                 />


### PR DESCRIPTION
Applied code fixes for Bug #161  :

Leave Code input will not be allowed more than 3 characters in HR Dashboard - Add Leave Category.

The new record will be displayed automatically in Leave Categories list after the clicking Save and Confirm button.

Also as per suggestion, added success message box after the Confirm button just to show that the new record has been added successfully.