### PR TITLE
Ashraf new employee max length

### DIFF
--- a/Client_CSILMS/package-lock.json
+++ b/Client_CSILMS/package-lock.json
@@ -7190,7 +7190,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {

--- a/Client_CSILMS/src/staffprofile/EditStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/EditStaffProfile.js
@@ -161,6 +161,7 @@ class EditStaffProfile extends Component {
               <Label for="mobileNo">Mobile No.</Label>
               <Input
                 type="text"
+                maxLength="15"
                 name="mobileNo"
                 id="mobileNo"
                 value={mobileNo}

--- a/Client_CSILMS/src/staffprofile/EditStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/EditStaffProfile.js
@@ -118,6 +118,7 @@ class EditStaffProfile extends Component {
               <Label for="name">Staff Name</Label>
               <Input
                 type="text"
+                maxLength="80"
                 name="name"
                 id="name"
                 value={name}

--- a/Client_CSILMS/src/staffprofile/EditStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/EditStaffProfile.js
@@ -129,6 +129,7 @@ class EditStaffProfile extends Component {
               <Label for="businessEmail">Email</Label>
               <Input
                 type="email"
+                maxLength="30"
                 name="businessEmail"
                 id="businessEmail"
                 value={businessEmail}

--- a/Client_CSILMS/src/staffprofile/EditStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/EditStaffProfile.js
@@ -140,6 +140,7 @@ class EditStaffProfile extends Component {
               <Label for="nricPassport">NRIC / Passport No.</Label>
               <Input
                 type="text"
+                maxLength="14"
                 name="nricPassport"
                 id="nricPassport"
                 value={nricPassport}

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -512,6 +512,7 @@ class NewStaffProfile extends Component {
                   <Col sm={10}>
                     <Input
                       type="text"
+                      maxLength="14"
                       name="icNumber"
                       id="icNumber"
                       placeholder="NRIC / Passport No."

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -613,11 +613,12 @@ class NewStaffProfile extends Component {
                   </Label>
                   <Col sm={10}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="marriageCount"
                       id="marriageCount"
                       placeholder="Marriage Count"
-                      onChange={this.handleChange}
+                      onChange={event => this.setState({marriageCount: event.target.value.replace(/\D/,'')})}
                       value={marriageCount}
                       required
                     />

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -684,6 +684,7 @@ class NewStaffProfile extends Component {
                   <Col sm={10}>
                     <Input
                       type="text"
+                      maxLength="15"
                       name="mobileNo"
                       id="mobileNo"
                       placeholder="Mobile No."

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -493,6 +493,7 @@ class NewStaffProfile extends Component {
                   <Col sm={10}>
                     <Input
                       type="email"
+                      maxLength="30"
                       name="email"
                       id="email"
                       ref="email"

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -457,6 +457,7 @@ class NewStaffProfile extends Component {
                   <Col sm={10}>
                     <Input
                       type="text"
+                      maxLength="10"
                       name="csiStaffId"
                       id="csiStaffId"
                       ref="csiStaffId"

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -476,6 +476,7 @@ class NewStaffProfile extends Component {
                   <Col sm={10}>
                     <Input
                       type="text"
+                      maxLength="80"
                       name="staffName"
                       id="staffName"
                       placeholder="Employee Name"

--- a/Client_CSILMS/src/staffprofile/NewStaffProfile.js
+++ b/Client_CSILMS/src/staffprofile/NewStaffProfile.js
@@ -630,11 +630,12 @@ class NewStaffProfile extends Component {
                   </Label>
                   <Col sm={10}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="totalChildren"
                       id="totalChildren"
                       placeholder="Total Children"
-                      onChange={this.handleChange}
+                      onChange={event => this.setState({totalChildren: event.target.value.replace(/\D/,'')})}
                       value={totalChildren}
                       required
                     />


### PR DESCRIPTION
Code fixes related to input field validation (maximum characters restriction) 
for #177, #178, #179, #180, #181, #182 and #183:

- Limit the length of character inputs for **`Employee ID`**, **`Name`**, **`Business Email`**, **`NRIC/Passport`**, **`Marriage Count`**, **`Total Children`** & **`Mobile No`** fields.
- Additional validation for **`Marriage Count`** & **`Total Children`** fields by preventing non-numerical inputs.
- Changes applied to both **New Employee** and **Edit Employee Profile** pages.
- Tested on most modern browsers: **_Chrome_**, **_Firefox_**, **_MS Edge_**, **_Internet Explorer_** and **_Opera_** (except for **_Safari_** Desktop).