### PR TITLE
Fix bug where cant add new entitlement

### DIFF
--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -168,6 +168,7 @@ class AddEntitlement extends Component {
     };
 
     const postRequest = Object.assign({}, jsonRowValues);
+    this.toggleConfirmSubmit();
 
     fetchData({
       url: API_BASE_URL + "/leaveentitlement",
@@ -175,7 +176,6 @@ class AddEntitlement extends Component {
       body: JSON.stringify(postRequest)
     })
       .then(response => {
-        this.toggleConfirmSubmit();
         confirmAlert({
           message: "Leave Entitlement has been successfully added!",
           buttons: [
@@ -238,7 +238,20 @@ class AddEntitlement extends Component {
         }          
       })
       .catch( error => {
-        return false;
+        if(error.hasOwnProperty("status")) {
+          confirmAlert({
+            message: error.status + " : " + error.message,
+            buttons: [
+              {
+                label: "OK"
+              }
+            ]
+          })  
+        } else 
+          // If Leave Entitlement Not Found, proceed to create
+          this.setState(prevState => ({
+            modalSubmit: !prevState.modalSubmit
+          }));
       })
   };
 


### PR DESCRIPTION
The check for existing Leave Entitlement (to avoid overwriting existing Leave entitlement), have erroneous handling. When no Leave Entitlement found for given key (ID + year + Leave Type), API response of NULL should allow user to create Leave Entitlement with the values. 