### PR TITLE
Chai bug186 refresh react table

### DIFF
--- a/Client_CSILMS/src/hradmin/EditEntitlement.js
+++ b/Client_CSILMS/src/hradmin/EditEntitlement.js
@@ -229,6 +229,13 @@ class EditEntitlement extends Component {
     })
   }
 
+  handleResetBalanceLeave = () => {
+    
+    this.setState({
+      balanceLeave: this.state.availableLeave - this.state.takenLeave
+    })
+  }
+
   render() {
     if (!isHrRole(this.props.currentUser)) {
       return <Redirect to="/forbidden" />;
@@ -304,7 +311,8 @@ class EditEntitlement extends Component {
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Balance does not tally ( Available Leave - Taken ) 
+        Balance does not tally ( Available Leave - Taken )  {  }
+        <Badge href="#" onClick={this.handleResetBalanceLeave} color="primary">Reset</Badge>
         </Alert>
       )
     

--- a/Client_CSILMS/src/hradmin/EditPublicHoliday.js
+++ b/Client_CSILMS/src/hradmin/EditPublicHoliday.js
@@ -145,11 +145,46 @@ class EditPublicHoliday extends Component {
 
     const { holidayDate } = this.props.computedMatch.params;
 
+    this.toggleDelete()
     fetchData({
       url: API_BASE_URL + "/publicholiday/" + holidayDate,
       method: "DELETE"
-    });
-    this.props.history.push("/publicholiday");
+    })
+    .then(data => {
+      confirmAlert({
+        message: "Public Holiday has been deleted.",
+        buttons: [
+          {
+            label: "OK",
+            onClick: () => this.props.history.push("/publicholiday")
+          }
+        ]
+      })
+    })
+    .catch(error => {
+      if (error.status === 401) {
+        this.props.history.push("/login");
+      } else if ( error.hasOwnProperty("status") ){
+        confirmAlert({
+          message: "Failed to delete Public Holiday, please try again later",
+          buttons: [
+            {
+              label: "OK"
+            }
+          ]
+        });
+      } else {
+        confirmAlert({
+          message: "Public Holiday has been deleted.",
+          buttons: [
+            {
+              label: "OK",
+              onClick: () => this.props.history.push("/publicholiday")
+            }
+          ]
+        })
+      }
+    });    
   }
 
   render() {


### PR DESCRIPTION
1. Fix Bug 186 - refresh React Table after `Delete Public Holiday`
2. Added button to reset Balance Leave on `Edit Leave Entitlement` page

Before
![image](https://user-images.githubusercontent.com/46370369/55308060-0d7d9780-548c-11e9-9b5e-a1ae0cf868fc.png)

After
![image](https://user-images.githubusercontent.com/46370369/55308067-140c0f00-548c-11e9-80ed-600c9b991f8a.png)
