### PR TITLE
Ashraf max digit leave entitments categories

### DIFF
--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -124,6 +124,7 @@ class AddEntitlement extends Component {
       !emplId ||
       !year ||
       !leaveCode ||
+      isNaN(year) ||
       carryForward === "" ||
       carryForward < 0 ||
       isNaN(carryForward) ||
@@ -258,6 +259,13 @@ class AddEntitlement extends Component {
       })
   };
 
+  validateYear(year) {
+    // Validate if year input is a number
+    if (isNaN(year)) {
+      return <Alert color="danger">Invalid number</Alert>;
+    }
+  }
+
   render() {
     if (!isHrRole(this.props.currentUser)) {
       return <Redirect to="/forbidden" />;
@@ -275,6 +283,8 @@ class AddEntitlement extends Component {
       takenLeave,
       balanceLeave
     } = this.state;
+
+    let yearErrorMsg = this.validateYear(year);
 
     let carryForwardMessage = "";
     if(isNaN(carryForward) || carryForward < 0)
@@ -358,9 +368,10 @@ class AddEntitlement extends Component {
                   name="year"
                   id="year"
                   placeholder="Leave Year"
-                  onChange={event => this.setState({ year: event.target.value.replace(/\D/,'')})}
+                  onChange={this.handleChangeLeaveEntitlement}
                   value={year}
                 />
+                <span>{yearErrorMsg}</span>
               </Col>
             </FormGroup>
             <FormGroup row>

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -261,7 +261,7 @@ class AddEntitlement extends Component {
 
   validateYear(year) {
     // Validate if year input is a number
-    if (isNaN(year)) {
+    if (isNaN(year) || year < 0) {
       return <Alert color="danger">Invalid number</Alert>;
     }
   }

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -129,6 +129,7 @@ class AddEntitlement extends Component {
       isNaN(carryForward) ||
       entitlement === "" ||
       entitlement < 0 ||
+      isNaN(entitlement) ||
       availableLeave === "" ||
       availableLeave < 0 ||
       takenLeave === "" ||
@@ -287,14 +288,14 @@ class AddEntitlement extends Component {
       )
 
     let entitlementMessage = "";
-    if (entitlement < 0)
+    if (isNaN(entitlement) || entitlement < 0)
       entitlementMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only 
         </Alert>
       )
 
@@ -412,7 +413,8 @@ class AddEntitlement extends Component {
               </Label>
               <Col xs={4} sm={2}>
                 <Input
-                  type="number"
+                  type="text"
+                  maxLength="2"
                   name="entitlement"
                   id="entitlement"
                   placeholder="Entitlement"

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -350,11 +350,13 @@ class AddEntitlement extends Component {
               </Label>
               <Col sm={10}>
                 <Input
-                  type="number"
+                  type="text"
+                  maxLength="4"
                   name="year"
                   id="year"
                   placeholder="Leave Year"
                   onChange={this.handleChangeLeaveEntitlement}
+                  onInput={event => this.setState({ year: event.target.value.replace(/\D/,'')})}
                   value={year}
                 />
               </Col>

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -126,6 +126,7 @@ class AddEntitlement extends Component {
       !leaveCode ||
       carryForward === "" ||
       carryForward < 0 ||
+      isNaN(carryForward) ||
       entitlement === "" ||
       entitlement < 0 ||
       availableLeave === "" ||
@@ -274,14 +275,14 @@ class AddEntitlement extends Component {
     } = this.state;
 
     let carryForwardMessage = "";
-    if(carryForward < 0)
+    if(isNaN(carryForward) || carryForward < 0)
       carryForwardMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only
         </Alert>
       )
 
@@ -356,7 +357,6 @@ class AddEntitlement extends Component {
                   id="year"
                   placeholder="Leave Year"
                   onChange={this.handleChangeLeaveEntitlement}
-                  onInput={event => this.setState({ year: event.target.value.replace(/\D/,'')})}
                   value={year}
                 />
               </Col>
@@ -393,7 +393,8 @@ class AddEntitlement extends Component {
               </Label>
               <Col xs={4} sm={2}>
                 <Input
-                  type="number"
+                  type="text"
+                  maxLength="2"
                   name="carryForward"
                   id="carryForward"
                   placeholder="Carried Forward"

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -132,6 +132,7 @@ class AddEntitlement extends Component {
       isNaN(entitlement) ||
       availableLeave === "" ||
       availableLeave < 0 ||
+      isNaN(availableLeave) ||
       takenLeave === "" ||
       balanceLeave === "";
     return isInvalid;
@@ -300,14 +301,14 @@ class AddEntitlement extends Component {
       )
 
     let availableLeaveMessage = "";
-    if(availableLeave < 0 )
+    if(isNaN(availableLeave) || availableLeave < 0 )
       availableLeaveMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only 
         </Alert>
       )
 
@@ -432,7 +433,8 @@ class AddEntitlement extends Component {
               </Label>
               <Col xs={4} sm={2}>
                 <Input
-                  type="number"
+                  type="text"
+                  maxLength="2"
                   name="availableLeave"
                   id="availableLeave"
                   placeholder="Available Leave"

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -358,7 +358,7 @@ class AddEntitlement extends Component {
                   name="year"
                   id="year"
                   placeholder="Leave Year"
-                  onChange={this.handleChangeLeaveEntitlement}
+                  onChange={event => this.setState({ year: event.target.value.replace(/\D/,'')})}
                   value={year}
                 />
               </Col>

--- a/Client_CSILMS/src/hradmin/AddLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/AddLeaveCategory.js
@@ -48,7 +48,7 @@ class AddLeaveCategory extends Component {
 
   validateFields = () => {
     const { leaveCode, leaveDescr, entitlement } = this.state;
-    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0;
+    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0 || isNaN(entitlement);
     return isInvalid;
   };
 

--- a/Client_CSILMS/src/hradmin/AddLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/AddLeaveCategory.js
@@ -48,7 +48,7 @@ class AddLeaveCategory extends Component {
 
   validateFields = () => {
     const { leaveCode, leaveDescr, entitlement } = this.state;
-    const isInvalid = !leaveCode || !leaveDescr || !entitlement;
+    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0;
     return isInvalid;
   };
 
@@ -108,7 +108,7 @@ class AddLeaveCategory extends Component {
 
   validateLeaveEnt(leaveEnt) {
     // Validate if input is a number
-    if (isNaN(leaveEnt)) {
+    if (isNaN(leaveEnt) || leaveEnt < 0) {
       return <Alert color="danger">Invalid number</Alert>;
     }
   }

--- a/Client_CSILMS/src/hradmin/AddLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/AddLeaveCategory.js
@@ -167,7 +167,8 @@ class AddLeaveCategory extends Component {
               </Label>
               <Col sm={10}>
                 <Input
-                  type="number"
+                  type="text"
+                  maxLength="2"
                   name="entitlement"
                   id="leaveEntitlement"
                   value={entitlement}

--- a/Client_CSILMS/src/hradmin/EditEntitlement.js
+++ b/Client_CSILMS/src/hradmin/EditEntitlement.js
@@ -207,10 +207,13 @@ class EditEntitlement extends Component {
     const isInvalid =
       carryForward === "" ||
       carryForward < 0 ||
+      isNaN(carryForward) ||
       entitlement === "" ||
       entitlement < 0 ||
+      isNaN(entitlement) ||
       availableLeave === "" ||
       availableLeave < 0 ||
+      isNaN(availableLeave) ||
       takenLeave === "" ||
       balanceLeave === "";
     return isInvalid;

--- a/Client_CSILMS/src/hradmin/EditEntitlement.js
+++ b/Client_CSILMS/src/hradmin/EditEntitlement.js
@@ -258,38 +258,38 @@ class EditEntitlement extends Component {
     } = this.state;
 
     let carryForwardMessage = "";
-    if(carryForward < 0)
+    if(isNaN(carryForward) || carryForward < 0)
       carryForwardMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only
         </Alert>
       )
 
     let entitlementMessage = "";
-    if (entitlement < 0)
+    if (isNaN(entitlement) || entitlement < 0)
       entitlementMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only
         </Alert>
       )
 
     let availableLeaveMessage = "";
-    if(availableLeave < 0 )
+    if(isNaN(availableLeave) || availableLeave < 0 )
       availableLeaveMessage = (
         <Alert 
           color="danger" 
           xs={4} sm={3} 
           style={{padding: ".25em 1em", margin: ".25em 1em"}} 
         > 
-        Positive number only 
+        Please enter a valid number only 
         </Alert>
       )
     
@@ -398,7 +398,8 @@ class EditEntitlement extends Component {
                   </Label>
                   <Col xs={4} sm={2}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="carryForward"
                       id="carryForward"
                       placeholder="Carried Forward"
@@ -415,7 +416,8 @@ class EditEntitlement extends Component {
                   </Label>
                   <Col xs={4} sm={2}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="entitlement"
                       id="entitlement"
                       placeholder="Entitlement"
@@ -432,7 +434,8 @@ class EditEntitlement extends Component {
                   </Label>
                   <Col xs={4} sm={2}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="availableLeave"
                       id="availableLeave"
                       placeholder="Available Leave"

--- a/Client_CSILMS/src/hradmin/EditLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/EditLeaveCategory.js
@@ -82,7 +82,7 @@ class EditLeaveCategory extends Component {
 
   validateFields = () => {
     const { leaveCode, leaveDescr, entitlement } = this.state;
-    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0;
+    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0  || isNaN(entitlement);
     return isInvalid;
   };
 

--- a/Client_CSILMS/src/hradmin/EditLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/EditLeaveCategory.js
@@ -82,7 +82,7 @@ class EditLeaveCategory extends Component {
 
   validateFields = () => {
     const { leaveCode, leaveDescr, entitlement } = this.state;
-    const isInvalid = !leaveCode || !leaveDescr || !entitlement;
+    const isInvalid = !leaveCode || !leaveDescr || !entitlement || entitlement < 0;
     return isInvalid;
   };
 
@@ -163,7 +163,7 @@ class EditLeaveCategory extends Component {
 
   validateLeaveEnt(leaveEnt) {
     // Validate if input is a number
-    if (isNaN(leaveEnt)) {
+    if (isNaN(leaveEnt) || leaveEnt < 0) {
       return <Alert color="danger">Invalid number</Alert>;
     }
   }

--- a/Client_CSILMS/src/hradmin/EditLeaveCategory.js
+++ b/Client_CSILMS/src/hradmin/EditLeaveCategory.js
@@ -227,7 +227,8 @@ class EditLeaveCategory extends Component {
                   </Label>
                   <Col sm={10}>
                     <Input
-                      type="number"
+                      type="text"
+                      maxLength="2"
                       name="entitlement"
                       id="leaveEntitlement"
                       value={entitlement}


### PR DESCRIPTION
Code fix for issue #202 (_**No limit on number input fields (Leave Entitlements & Categories)**_) and applied changes for below modules.

Tested on **`Chrome`**, **`Firefox`** and **`Internet Explorer`** browsers without any issue.

###  **Add Leave Entitlement**
- Error message if **Leave Year** is not a valid number or negative value and can input up to 4 digits only.
- Error message if **Carried Forward** is not a valid number or negative value and can input up to 2 digits only.
- Error message if **Entitlement** is not a valid number or negative value and can input up to 2 digits only.
- Error message if **Available Leave** is not a valid number or negative value and can input up to 2 digits only.
- **Save** button is disabled if all above requirements are not met.

###  **Edit Leave Entitlement**
- Error message if **Carried Forward** is not a valid number or negative value and can input up to 2 digits only.
- Error message if **Entitlement** is not a valid number or negative value and can input up to 2 digits only.
- Error message if **Available Leave** is not a valid number or negative value and can input up to 2 digits only.
- **Save** button is disabled if all above requirements are not met.

### **Add Leave Category**
- Error message if **Leave Entitlement** is not a valid number or negative value and can input up to 2 digits only.
- **Save** button is disabled if above requirement is not met.

### **Edit Leave Category**
- Error message if **Leave Entitlement** is not a valid number or negative value and can input up to 2 digits only.
- **Save** button is disabled if above requirement is not met.
