### PR TITLE
Chai fix check when adding new record

### DIFF
--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/LeaveCategoryRestController.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/LeaveCategoryRestController.java
@@ -1,8 +1,6 @@
 package com.csi.leavemanagement.controllers;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -16,9 +14,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.csi.leavemanagement.services.LeaveCategoryService;
 import com.csi.leavemanagement.exceptions.LeaveCategoryServiceException;
 import com.csi.leavemanagement.models.LeaveCategory;
+import com.csi.leavemanagement.services.LeaveCategoryService;
 
 @RestController
 @RequestMapping("/api")

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/PublicHolidayRestController.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/PublicHolidayRestController.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,7 +16,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+import com.csi.leavemanagement.exceptions.PublicHolidayServiceException;
 import com.csi.leavemanagement.models.PublicHoliday;
 import com.csi.leavemanagement.services.PublicHolidayService;
 
@@ -56,9 +60,38 @@ public class PublicHolidayRestController {
     
     @RequestMapping(value="/publicholiday", method=RequestMethod.POST)
 	@PreAuthorize("hasAuthority('HR')")
-    public PublicHoliday doSavePublicHoliday(@RequestBody PublicHoliday publicHoliday) {
-        PublicHoliday newPublicHoliday = this.publicHolidayService.save(publicHoliday);
-        return newPublicHoliday;
+    public ResponseEntity<?> doCreatePublicHoliday(@RequestBody PublicHoliday publicHoliday) {
+    	
+        PublicHoliday newPublicHoliday = null;        
+		try {			
+			newPublicHoliday = this.publicHolidayService.create(publicHoliday);			
+		} catch (PublicHolidayServiceException e) {
+			
+			String errorMessage = "";
+			switch(e.getExceptionCode()) {
+				case PublicHolidayServiceException.PUBLIC_HOLIDAY_ALREADY_EXIST:
+					SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+					String holidayDate = sdf.format(publicHoliday.getHolidayDate());
+					errorMessage = holidayDate + " is already a Public Holiday";
+					break;
+					
+				case PublicHolidayServiceException.PUBLIC_HOLIDAY_INVALID_DATE:
+					errorMessage = "Date specified is invalid";
+					break;
+					
+				default:
+					errorMessage = "An unknown error has occured";
+			}
+			throw new ResponseStatusException(HttpStatus.CONFLICT, errorMessage);
+			
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "An unknown error has occured");
+		}
+		
+		if(newPublicHoliday == null) 
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create Public Holiday");
+		
+        return new ResponseEntity<PublicHoliday>(newPublicHoliday, HttpStatus.CREATED);
     }
     
     @RequestMapping(value="/publicholiday/{id}", method=RequestMethod.DELETE)

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/TranslateitemRestController.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/TranslateitemRestController.java
@@ -1,8 +1,12 @@
 package com.csi.leavemanagement.controllers;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+import com.csi.leavemanagement.exceptions.TranslateItemServiceException;
 import com.csi.leavemanagement.models.Translateitem;
 import com.csi.leavemanagement.services.TranslateitemService;
 
@@ -48,9 +54,36 @@ public class TranslateitemRestController {
 	
 	@RequestMapping(value="/translateitem", method=RequestMethod.POST)
 	@PreAuthorize("hasAuthority('HR')")
-	public Translateitem doSaveTranslateitem(@RequestBody Translateitem translateitem) {
-		Translateitem newTranslateitem = this.translateitemService.save(translateitem);
-		return newTranslateitem;
+	public ResponseEntity<?> doCreateTranslateitem(@RequestBody Translateitem translateitem) {
+		
+		Translateitem newTranslateitem = null;
+		try {			
+			newTranslateitem = this.translateitemService.create(translateitem);			
+		} catch (TranslateItemServiceException e) {
+			
+			String errorMessage = "";
+			switch(e.getExceptionCode()) {
+				case TranslateItemServiceException.TRANSLATE_ITEM_ALREADY_EXIST:
+					errorMessage = translateitem.getId().getFieldvalue() + " already defined for " + translateitem.getId().getFieldname();
+					break;
+					
+				case TranslateItemServiceException.TRANSLATE_ITEM_INVALID_FIELDNAME:
+					errorMessage = translateitem.getId().getFieldname() + " is not a valid field name";
+					break;
+				
+				default:
+					errorMessage = "An unknown error has occured";					
+			}
+			throw new ResponseStatusException(HttpStatus.CONFLICT, errorMessage);
+
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "An unknown error has occured");
+		}
+		
+		if(newTranslateitem == null) 
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create Translate Item");
+				
+		return new ResponseEntity<Translateitem>(newTranslateitem, HttpStatus.CREATED);
 	}
 	
 	@RequestMapping(value="/translateitem/{fieldname}", method=RequestMethod.DELETE)

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/TranslateitemRestController.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/controllers/TranslateitemRestController.java
@@ -1,8 +1,6 @@
 package com.csi.leavemanagement.controllers;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/LeaveCategoryServiceException.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/LeaveCategoryServiceException.java
@@ -1,0 +1,57 @@
+package com.csi.leavemanagement.exceptions;
+
+public class LeaveCategoryServiceException extends Exception {
+
+	/** For CREATE operation when record with same primary key is found */
+	public final static int LEAVE_CATEGORY_ALREADY_EXIST = 1;
+	
+	/** For READ, UPDATE, DELETE operation when primary key not found */
+	public final static int LEAVE_CATEGORY_NOT_FOUND = 2;
+	
+	/** For undefined exception code */
+	public final static int LEAVE_CATEGORY_UNDEFINED = 99;
+	
+	/** Code for this Translate Item Service Exception*/
+	private int exceptionCode;
+
+	/** 
+	 * Constructs a new Leave Category Service Exception of specified exception code and detail message 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 */
+	public LeaveCategoryServiceException(int exceptionCode) {
+		super();
+		this.setExceptionCode(exceptionCode);
+	}
+	
+	/** 
+	 * Constructs a new Leave Category Service Exception of specified exception code and detail message 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 * @param message The detail message for this exception. The detail message is saved for later retrieval by the {@link java.lang.Throwable#getMessage()} method.
+	 */
+	public LeaveCategoryServiceException(int exceptionCode, String message) {
+		super(message);
+		this.setExceptionCode(exceptionCode);
+	}
+
+	/** 
+	 * Returns the Exception Code of this Leave Category Service Exception.
+	 * @return the exception code of this Leave Category Service Exception instance
+	 */
+	public int getExceptionCode() {
+		return exceptionCode;
+	}
+
+	public void setExceptionCode(int exceptionCode) {
+		switch(exceptionCode) {
+			case LEAVE_CATEGORY_ALREADY_EXIST:
+			case LEAVE_CATEGORY_NOT_FOUND:
+				this.exceptionCode = exceptionCode;
+				break;
+			
+			default:
+				this.exceptionCode = LEAVE_CATEGORY_UNDEFINED;
+		}
+	}
+	
+	
+}

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/PublicHolidayServiceException.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/PublicHolidayServiceException.java
@@ -1,0 +1,58 @@
+package com.csi.leavemanagement.exceptions;
+
+public class PublicHolidayServiceException extends Exception {
+
+	/** For CREATE operation when record with same primary key is found */
+	public static final int PUBLIC_HOLIDAY_ALREADY_EXIST = 1;
+	
+	/** For READ, UPDATE, DELETE operation when primary key not found */
+	public static final int PUBLIC_HOLIDAY_NOT_FOUND = 2;
+	
+	/** Date value is invalid */
+	public static final int PUBLIC_HOLIDAY_INVALID_DATE = 3;
+	
+	/** For undefined exception code */
+	public static final int PUBLIC_HOLIDAY_UNDEFINED = 99;
+	
+	/** Code for this Public Holiday Service Exception*/
+	private int exceptionCode;
+	
+	/** 
+	 * Constructs a new Public Holiday Service Exception of specified exception code 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 */
+	public PublicHolidayServiceException(int exceptionCode) {
+		super();
+		this.setExceptionCode(exceptionCode);
+	}
+
+	/** 
+	 * Constructs a new Public Holiday Service Exception of specified exception code and detail message 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 * @param message The detail message for this exception. The detail message is saved for later retrieval by the {@link java.lang.Throwable#getMessage()} method.
+	 */
+	public PublicHolidayServiceException(int exceptionCode, String message) {
+		super(message);
+		this.setExceptionCode(exceptionCode);
+	}
+	
+	/** 
+	 * Returns the Exception Code of this Public Holiday Service Exception.
+	 * @return the exception code of this Public Holiday Service Exception instance
+	 */
+	public int getExceptionCode() {
+		return this.exceptionCode;
+	}
+	
+	private void setExceptionCode(int exceptionCode) {
+		switch(exceptionCode) {
+			case PUBLIC_HOLIDAY_ALREADY_EXIST:
+			case PUBLIC_HOLIDAY_NOT_FOUND:
+			case PUBLIC_HOLIDAY_INVALID_DATE:
+				this.exceptionCode = exceptionCode;
+				break;
+			default :
+				this.exceptionCode = PUBLIC_HOLIDAY_UNDEFINED;
+		}
+	}
+}

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/TranslateItemServiceException.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/exceptions/TranslateItemServiceException.java
@@ -1,0 +1,60 @@
+package com.csi.leavemanagement.exceptions;
+
+public class TranslateItemServiceException extends Exception {
+
+	/** For CREATE operation when record with same primary key is found */
+	public final static int TRANSLATE_ITEM_ALREADY_EXIST = 1;
+	
+	/** For READ, UPDATE, DELETE operation when primary key not found */
+	public final static int TRANSLATE_ITEM_NOT_FOUND = 2;
+	
+	/** Field name provided is invalid */
+	public final static int TRANSLATE_ITEM_INVALID_FIELDNAME = 3;
+	
+	/** For undefined exception code */
+	public final static int TRANSLATE_ITEM_UNDEFINED = 99;
+	
+	/** Code for this Translate Item Service Exception*/
+	private int exceptionCode;
+
+	/** 
+	 * Constructs a new Translate Item Service Exception of specified exception code and detail message 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 */
+	public TranslateItemServiceException(int exceptionCode) {
+		super();
+		this.setExceptionCode(exceptionCode);
+	}
+
+	/** 
+	 * Constructs a new Translate Item Service Exception of specified exception code and detail message 
+	 * @param exceptionCode The code for this exception. The exception code is saved for later retrieval by {@link #getExceptionCode()}) method
+	 * @param message The detail message for this exception. The detail message is saved for later retrieval by the {@link java.lang.Throwable#getMessage()} method.
+	 */
+	public TranslateItemServiceException(int exceptionCode, String message) {
+		super(message);
+		this.setExceptionCode(exceptionCode);
+	}
+	
+	/** 
+	 * Returns the Exception Code of this Translate Item Service Exception.
+	 * @return the exception code of this Translate Item Service Exception instance
+	 */
+	public int getExceptionCode() {
+		return exceptionCode;
+	}
+
+	private void setExceptionCode(int exceptionCode) {
+		switch(exceptionCode) {
+			case TRANSLATE_ITEM_ALREADY_EXIST:
+			case TRANSLATE_ITEM_NOT_FOUND:
+			case TRANSLATE_ITEM_INVALID_FIELDNAME:
+				this.exceptionCode = exceptionCode;
+				break;
+			default:
+				this.exceptionCode = TRANSLATE_ITEM_UNDEFINED;
+		}
+	}
+	
+	
+}

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/LeaveCategoryService.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/LeaveCategoryService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.csi.leavemanagement.exceptions.LeaveCategoryServiceException;
 import com.csi.leavemanagement.models.LeaveCategory;
 import com.csi.leavemanagement.repositories.LeaveCategoryRepository;
 
@@ -21,6 +22,15 @@ public class LeaveCategoryService {
 	public List<LeaveCategory> findAll() {
 		List<LeaveCategory> leaveCategories = (List<LeaveCategory>)this.leaveCategoryRepository.findAll();
 		return leaveCategories;
+	}
+	
+	public LeaveCategory create(LeaveCategory newLeaveCategory) throws LeaveCategoryServiceException {
+		
+		LeaveCategory leaveCategoryCheck = this.findById(newLeaveCategory.getLeaveCode());
+		if(leaveCategoryCheck != null)
+			throw new LeaveCategoryServiceException(LeaveCategoryServiceException.LEAVE_CATEGORY_ALREADY_EXIST);
+		
+		return this.leaveCategoryRepository.save(newLeaveCategory);
 	}
 	
 	public LeaveCategory save(LeaveCategory leaveCategory) {

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/PublicHolidayService.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/PublicHolidayService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.csi.leavemanagement.models.LeaveCategory;
+import com.csi.leavemanagement.exceptions.PublicHolidayServiceException;
 import com.csi.leavemanagement.models.PublicHoliday;
 import com.csi.leavemanagement.repositories.PublicHolidayRepository;
 
@@ -23,6 +23,15 @@ public class PublicHolidayService {
 	public List<PublicHoliday> findAll() {
 		List<PublicHoliday> publicHolidayList = (List<PublicHoliday>) this.publicHolidayRepository.findAll();
 		return publicHolidayList;
+	}
+	
+	public PublicHoliday create(PublicHoliday publicHoliday) throws PublicHolidayServiceException {
+    	
+    	PublicHoliday publicHolidayCheck = this.findById(publicHoliday.getHolidayDate());
+    	if(publicHolidayCheck != null)
+    		throw new PublicHolidayServiceException(PublicHolidayServiceException.PUBLIC_HOLIDAY_ALREADY_EXIST);
+    	
+		return this.publicHolidayRepository.save(publicHoliday);
 	}
 	
 	public PublicHoliday save(PublicHoliday publicHoliday) {

--- a/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/TranslateitemService.java
+++ b/Server_CSILMS/src/main/java/com/csi/leavemanagement/services/TranslateitemService.java
@@ -5,8 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.csi.leavemanagement.models.LeaveEntitlement;
-import com.csi.leavemanagement.models.LeaveEntitlementId;
+import com.csi.leavemanagement.exceptions.TranslateItemServiceException;
 import com.csi.leavemanagement.models.Translateitem;
 import com.csi.leavemanagement.models.TranslateitemId;
 import com.csi.leavemanagement.repositories.TranslateitemRepository;
@@ -24,6 +23,15 @@ public class TranslateitemService {
 	public List<Translateitem> findAll() {
 		List<Translateitem> translateitemList = (List<Translateitem>)this.translateitemRepository.findAll();
 		return translateitemList;
+	}
+	
+	public Translateitem create(Translateitem newTranslateitem) throws TranslateItemServiceException {
+		
+		Translateitem translateItemCheck = this.findById(newTranslateitem.getId());
+		if(translateItemCheck != null)
+			throw new TranslateItemServiceException(TranslateItemServiceException.TRANSLATE_ITEM_ALREADY_EXIST);
+		
+		return this.translateitemRepository.save(newTranslateitem);
 	}
 	
 	public Translateitem save(Translateitem newTranslateitem) {


### PR DESCRIPTION
- Added 3 Exception class for `Leave Category`, `Public Holiday`, `Translate Item`. It covers exceptions on create new record, and for future enhancement (e.g. 404 Not Found on GET request)
- Added `Create` method to handle creating new record, differs from `Save`, where `Create `will verify if Key / ID of the new record exist in Database. If exist, throw an exception.
- Change POST requests to use `Create` method for creating new record, and throw `ResponseStatusException `when there's error (e.g. 409 Conflict when ID already exist in DB)