### PR TITLE
Further increase the limit of PH descr

### DIFF
--- a/Client_CSILMS/src/hradmin/AddPublicHoliday.js
+++ b/Client_CSILMS/src/hradmin/AddPublicHoliday.js
@@ -196,7 +196,7 @@ class AddPublicHoliday extends Component {
               <Col sm={10}>
                 <Input
                   type="text"
-                  maxLength="30"
+                  maxLength="50"
                   name="holidayDescr"
                   id="holiday"
                   value={holidayDescr}

--- a/Client_CSILMS/src/hradmin/EditPublicHoliday.js
+++ b/Client_CSILMS/src/hradmin/EditPublicHoliday.js
@@ -252,7 +252,7 @@ class EditPublicHoliday extends Component {
                   <Col sm={10}>
                     <Input
                       type="text"
-                      maxLength="30"
+                      maxLength="50"
                       name="holidayDescr"
                       id="holiday"
                       value={holidayDescr}


### PR DESCRIPTION
The description field length is not sufficient for public holiday list received from HR. Following 2 entry exceeded limit:

- Hari Raya Haji (Replacement Day) : 32 char
- Awal Muharram (Replacement Day) : 31 char