### PR TITLE
Ashraf expand halfDay 5chars entitlements

### DIFF
--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -407,7 +407,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="4"
+                  maxLength="5"
                   name="carryForward"
                   id="carryForward"
                   placeholder="Carried Forward"
@@ -426,7 +426,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="4"
+                  maxLength="5"
                   name="entitlement"
                   id="entitlement"
                   placeholder="Entitlement"
@@ -445,7 +445,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="4"
+                  maxLength="5"
                   name="availableLeave"
                   id="availableLeave"
                   placeholder="Available Leave"

--- a/Client_CSILMS/src/hradmin/AddEntitlement.js
+++ b/Client_CSILMS/src/hradmin/AddEntitlement.js
@@ -407,7 +407,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="2"
+                  maxLength="4"
                   name="carryForward"
                   id="carryForward"
                   placeholder="Carried Forward"
@@ -426,7 +426,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="2"
+                  maxLength="4"
                   name="entitlement"
                   id="entitlement"
                   placeholder="Entitlement"
@@ -445,7 +445,7 @@ class AddEntitlement extends Component {
               <Col xs={4} sm={2}>
                 <Input
                   type="text"
-                  maxLength="2"
+                  maxLength="4"
                   name="availableLeave"
                   id="availableLeave"
                   placeholder="Available Leave"

--- a/Client_CSILMS/src/hradmin/EditEntitlement.js
+++ b/Client_CSILMS/src/hradmin/EditEntitlement.js
@@ -399,7 +399,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="2"
+                      maxLength="4"
                       name="carryForward"
                       id="carryForward"
                       placeholder="Carried Forward"
@@ -417,7 +417,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="2"
+                      maxLength="4"
                       name="entitlement"
                       id="entitlement"
                       placeholder="Entitlement"
@@ -435,7 +435,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="2"
+                      maxLength="4"
                       name="availableLeave"
                       id="availableLeave"
                       placeholder="Available Leave"

--- a/Client_CSILMS/src/hradmin/EditEntitlement.js
+++ b/Client_CSILMS/src/hradmin/EditEntitlement.js
@@ -399,7 +399,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="4"
+                      maxLength="5"
                       name="carryForward"
                       id="carryForward"
                       placeholder="Carried Forward"
@@ -417,7 +417,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="4"
+                      maxLength="5"
                       name="entitlement"
                       id="entitlement"
                       placeholder="Entitlement"
@@ -435,7 +435,7 @@ class EditEntitlement extends Component {
                   <Col xs={4} sm={2}>
                     <Input
                       type="text"
-                      maxLength="4"
+                      maxLength="5"
                       name="availableLeave"
                       id="availableLeave"
                       placeholder="Available Leave"


### PR DESCRIPTION
Fix for issue #214 and #215  :

Increase max length to **`5 chars`** for **Carried Forward**, **Entitlement** and **Available Leave** inputs under **Entitlements** modules (Add/Edit).

HR can input values from **`0.5`** and exceeding **`99`** days (based on certain HR case).