### PR TITLE
(Phase II) When Leave Request Attachment is clicked, attachment will be opened directly in another window/tab.

### DIFF
--- a/Client_CSILMS/src/leaves/ApplyLeave.js
+++ b/Client_CSILMS/src/leaves/ApplyLeave.js
@@ -725,10 +725,12 @@ class ApplyLeave extends Component {
                       type="file"
                       name="attachment"
                       id="attachment"
+                      accept=".pdf,.jpg,.jpeg,.jpe,.jfif,.gif,.bmp,.png"
                       onChange={this.handleChange}
                     />
                     <FormText color="muted">
-                      Please attach your document (maximum file size is 5 MB).
+                      Preferred attachment file type is .pdf, .gif, .jpg, .jpeg,
+                      .png or .bmp (file size must not exceed 5MB)
                     </FormText>
                   </Col>
                 </FormGroup>

--- a/Client_CSILMS/src/leaves/MyLeaveHistoryView.js
+++ b/Client_CSILMS/src/leaves/MyLeaveHistoryView.js
@@ -5,6 +5,7 @@ import {
   FormGroup,
   Label,
   Input,
+  CustomInput,
   FormText,
   Col,
   Modal,
@@ -28,6 +29,7 @@ class MyLeaveHistoryView extends Component {
       startDate: "",
       endDate: "",
       leaveDuration: "1 day(s)",
+      isHalfDay: "N",
       leaveReason: "",
       approver: "",
       approverName: "",
@@ -84,6 +86,7 @@ class MyLeaveHistoryView extends Component {
           startDate: data.id.startDate,
           endDate: data.endDate,
           leaveDuration: data.leaveDuration + " day(s)",
+          isHalfDay: data.halfDay,
           leaveReason: data.reason,
           approver: data.approver,
           leaveStatus: data.leaveStatus,
@@ -114,14 +117,16 @@ class MyLeaveHistoryView extends Component {
       });
   };
 
-  getAttachement = () => {
-    if (this.state.attachment !== "") {
+  getAttachment = () => {
+    let attachmentFile = this.state.attachment;
+    if (attachmentFile !== "") {
       fetchFile({
         url: API_BASE_URL + "/attachment/files/" + this.state.attachment,
         method: "GET"
       })
         .then(response => response.blob())
         .then(blob => {
+          /*
           // 2. Create blob link to download
           const url = window.URL.createObjectURL(new Blob([blob]));
           const link = document.createElement("a");
@@ -133,6 +138,50 @@ class MyLeaveHistoryView extends Component {
           link.click();
           // 5. Clean up and remove the link
           link.parentNode.removeChild(link);
+          */
+          let contentType = "";
+          switch (
+            attachmentFile
+              .split(".")
+              .pop()
+              .toLowerCase()
+          ) {
+            case "pdf":
+              contentType = "application/pdf";
+              break;
+            case "jpg":
+            case "jpe":
+            case "jfif":
+            case "jpeg":
+              contentType = "image/jpg";
+              break;
+            case "png":
+              contentType = "image/png";
+              break;
+            case "gif":
+              contentType = "image/gif";
+              break;
+            case "bmp":
+              contentType = "image/bmp";
+              break;
+            default:
+              contentType = "";
+              break;
+          }
+          if (contentType) {
+            const url = URL.createObjectURL(
+              new Blob([blob], { type: contentType })
+            );
+            window.open(url);
+          } else {
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute("download", attachmentFile);
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+          }
         })
         .catch(err => {
           alert(err);
@@ -310,6 +359,7 @@ class MyLeaveHistoryView extends Component {
       startDate,
       endDate,
       leaveDuration,
+      isHalfDay,
       leaveReason,
       approverName,
       leaveStatus,
@@ -329,6 +379,13 @@ class MyLeaveHistoryView extends Component {
     //     return "Rejected";
     //   }
     // };
+    const BooleanHalfDay = strHalfDay => {
+      if (strHalfDay === "Y") {
+        return true;
+      } else {
+        return false;
+      }
+    };
 
     const getLeaveStatusDesc = strLeaveStatus => {
       let arrLeaveStatusLookup = this.state.leaveStatusLookup;
@@ -369,7 +426,7 @@ class MyLeaveHistoryView extends Component {
     const showAttachment = attachment => {
       if (attachment !== "") {
         return (
-          <Button color="link" onClick={this.getAttachement}>
+          <Button color="link" onClick={this.getAttachment}>
             {" "}
             {attachment}
           </Button>
@@ -422,7 +479,7 @@ class MyLeaveHistoryView extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Label for="leaveDescr" sm={2}>
-                    Leave Category:
+                    Leave Type:
                   </Label>
                   <Col sm={10}>
                     <Input
@@ -473,6 +530,20 @@ class MyLeaveHistoryView extends Component {
                       id="leaveDuration"
                       value={leaveDuration}
                       placeholder="Days"
+                      disabled={true}
+                    />
+                  </Col>
+                </FormGroup>
+                <FormGroup row>
+                  <Label for="endDate" sm={2}>
+                    Taking Half Day?
+                  </Label>
+                  <Col sm={10}>
+                    <CustomInput
+                      type="checkbox"
+                      id="isHalfDay"
+                      label=""
+                      checked={BooleanHalfDay(isHalfDay)}
                       disabled={true}
                     />
                   </Col>

--- a/Client_CSILMS/src/manager/LeaveHistoryView.js
+++ b/Client_CSILMS/src/manager/LeaveHistoryView.js
@@ -102,13 +102,15 @@ class LeaveHistoryView extends Component {
   };
 
   getAttachement = () => {
-    if (this.state.attachment !== "") {
+    let attachmentFile = this.state.attachment;
+    if (attachmentFile !== "") {
       fetchFile({
         url: API_BASE_URL + "/attachment/files/" + this.state.attachment,
         method: "GET"
       })
         .then(response => response.blob())
         .then(blob => {
+          /*
           // 2. Create blob link to download
           const url = window.URL.createObjectURL(new Blob([blob]));
           const link = document.createElement("a");
@@ -120,6 +122,50 @@ class LeaveHistoryView extends Component {
           link.click();
           // 5. Clean up and remove the link
           link.parentNode.removeChild(link);
+          */
+          let contentType = "";
+          switch (
+            attachmentFile
+              .split(".")
+              .pop()
+              .toLowerCase()
+          ) {
+            case "pdf":
+              contentType = "application/pdf";
+              break;
+            case "jpg":
+            case "jpe":
+            case "jfif":
+            case "jpeg":
+              contentType = "image/jpg";
+              break;
+            case "png":
+              contentType = "image/png";
+              break;
+            case "gif":
+              contentType = "image/gif";
+              break;
+            case "bmp":
+              contentType = "image/bmp";
+              break;
+            default:
+              contentType = "";
+              break;
+          }
+          if (contentType) {
+            const url = URL.createObjectURL(
+              new Blob([blob], { type: contentType })
+            );
+            window.open(url);
+          } else {
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute("download", attachmentFile);
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+          }
         })
         .catch(err => {
           alert(err);
@@ -258,7 +304,7 @@ class LeaveHistoryView extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Label for="leaveDescr" sm={2}>
-                    Leave Category:
+                    Leave Type:
                   </Label>
                   <Col sm={10}>
                     <Input

--- a/Client_CSILMS/src/manager/LeaveRequest.js
+++ b/Client_CSILMS/src/manager/LeaveRequest.js
@@ -256,13 +256,15 @@ class LeaveRequest extends Component {
   };
 
   getAttachement = () => {
-    if (this.state.attachment !== "") {
+    let attachmentFile = this.state.attachment;
+    if (attachmentFile !== "") {
       fetchFile({
         url: API_BASE_URL + "/attachment/files/" + this.state.attachment,
         method: "GET"
       })
         .then(response => response.blob())
         .then(blob => {
+          /*
           // 2. Create blob link to download
           const url = window.URL.createObjectURL(new Blob([blob]));
           const link = document.createElement("a");
@@ -274,6 +276,50 @@ class LeaveRequest extends Component {
           link.click();
           // 5. Clean up and remove the link
           link.parentNode.removeChild(link);
+          */
+          let contentType = "";
+          switch (
+            attachmentFile
+              .split(".")
+              .pop()
+              .toLowerCase()
+          ) {
+            case "pdf":
+              contentType = "application/pdf";
+              break;
+            case "jpg":
+            case "jpe":
+            case "jfif":
+            case "jpeg":
+              contentType = "image/jpg";
+              break;
+            case "png":
+              contentType = "image/png";
+              break;
+            case "gif":
+              contentType = "image/gif";
+              break;
+            case "bmp":
+              contentType = "image/bmp";
+              break;
+            default:
+              contentType = "";
+              break;
+          }
+          if (contentType) {
+            const url = URL.createObjectURL(
+              new Blob([blob], { type: contentType })
+            );
+            window.open(url);
+          } else {
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute("download", attachmentFile);
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+          }
         })
         .catch(err => {
           alert(err);
@@ -554,7 +600,7 @@ class LeaveRequest extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Label for="leaveDescr" sm={2}>
-                    Leave Category:
+                    Leave Type:
                   </Label>
                   <Col sm={10}>
                     <Input


### PR DESCRIPTION
Changes covers the following:
-> "AppliedLeave.js" page - Added file types preference on uploading File Attachment, those preferred file types are common and light weight like .pdf, .gif, .jpg, .jpeg, .png and .bmp but user can forcefully upload other file types if they desired to.
-> "MyLeaveHistoryView.js", "LeaveRequest.js" & "LeaveHistoryView.js" pages - Added the functionality on clicking the File Attachment link. File Attachment will be opened/viewed on a separate window/tab if attachment file type is in the preferred file types. If not, attachment will be downloaded instead.
-> "MyLeaveHistoryView.js" page - Added the missing field: HalfDay checkbox.